### PR TITLE
80 backend create endpoint tests

### DIFF
--- a/src/statego-backend/Cargo.lock
+++ b/src/statego-backend/Cargo.lock
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -2350,6 +2350,7 @@ dependencies = [
  "mysql_common 0.31.0",
  "openssl",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/src/statego-backend/Cargo.toml
+++ b/src/statego-backend/Cargo.toml
@@ -19,3 +19,19 @@ mysql = "24"
 mysql_common = {version = "0.31.0", features = ["chrono"]}
 openssl = {version = "0.10.57", features = ["v110"]}
 serde = "1.0.188"
+
+[dev-dependencies]
+actix = "0.11.0"
+actix-rt = "2.2"
+actix-web = {version = "4", features = ["openssl"]}
+bcrypt = "0.15.0"
+chrono = {version = "0.4.31", features = ["serde"]}
+derive_more = "0.99.17"
+dotenv = "0.15"
+env_logger = "0.10.0"
+log = "0.4.20"
+mysql = "24"
+mysql_common = {version = "0.31.0", features = ["chrono"]}
+openssl = {version = "0.10.57", features = ["v110"]}
+serde = "1.0.188"
+serde_json = "1.0.108"

--- a/src/statego-backend/src/main.rs
+++ b/src/statego-backend/src/main.rs
@@ -39,6 +39,7 @@ async fn main() -> io::Result<()> {
             .service(routes::create_campaign)
             .service(routes::get_list_of_games)
             .service(routes::get_list_of_campaigns)
+            .service(routes::get_single_user)
     })
     .bind(("127.0.0.1", 8080))?
     .workers(2)

--- a/src/statego-backend/src/models.rs
+++ b/src/statego-backend/src/models.rs
@@ -26,6 +26,31 @@ pub struct UserData {
     pub last_name: String,
 }
 
+
+#[derive(Debug, Serialize, FromRow)]
+pub struct SingleUserUnconvertedResponseData {
+    //pub create_time: String,
+    pub email: String,
+    pub username: String,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub pronouns: Option<String>,
+    pub bio: Option<String>,
+    pub profile_pic: Option<String>
+}
+
+#[derive(Debug, Serialize, PartialEq, Deserialize)]
+pub struct SingleUserConvertedResponseData {
+    //pub create_time: NaiveDateTime,
+    pub email: String,
+    pub username: String,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub pronouns: Option<String>,
+    pub bio: Option<String>,
+    pub profile_pic: Option<String>
+}
+
 #[derive(Debug, Serialize)]
 pub struct UserResponseData {
     pub user_data: Vec<UserData>,

--- a/src/statego-backend/src/persistence.rs
+++ b/src/statego-backend/src/persistence.rs
@@ -21,7 +21,7 @@ pub enum PersistenceError {
     BcryptError(bcrypt::BcryptError),
     MysqlError(mysql::Error),
     UnknownUser,
-    Unknown,
+    Unknown
 }
 
 //matches a PersistenceError to a StatusCode
@@ -107,6 +107,40 @@ pub fn get_users_verify(pool: &mysql::Pool) -> Result<UserResponseData, Persiste
     Ok(UserResponseData {
         user_data: select_all_users(&mut conn)?,
     })
+}
+
+pub fn get_single_user_persistence(pool: &mysql::Pool, username: String) -> Result<SingleUserConvertedResponseData, PersistenceError> {
+    let mut conn = pool.get_conn()?;
+
+    if username.replace(' ', "").trim().is_empty() {
+        return Err(PersistenceError::EmptyUsername);
+    }
+    //get user_id
+    let user_id = select_userid_by_userstring(&mut conn, username).unwrap();
+    let single_user = select_single_user(&mut conn, user_id).unwrap();
+    //let create_time_vec: Vec<&str> = single_user.create_time.split(',').collect();
+    //let year = create_time_vec[0].parse::<i32>();
+    //let month = create_time_vec[1].parse::<u32>();
+    //let day = create_time_vec[2].parse::<u32>();
+    //let hour = create_time_vec[3].parse::<u32>();
+    //let minute = create_time_vec[4].parse::<u32>();
+    //let second = create_time_vec[5].parse::<u32>();
+    //let date = NaiveDate::from_ymd_opt(year.unwrap(), month.unwrap(), day.unwrap()).unwrap();
+    //let time = NaiveTime::from_hms_opt(hour.unwrap(), minute.unwrap(), second.unwrap()).unwrap();
+    //let create_time_datetime = NaiveDateTime::new(date, time);
+
+    let single_user_converted = SingleUserConvertedResponseData {
+        //create_time: create_time_datetime,
+        email: single_user.email,
+        username: single_user.username,
+        first_name: single_user.first_name,
+        last_name: single_user.last_name,
+        pronouns: single_user.pronouns,
+        bio: single_user.bio,
+        profile_pic: single_user.profile_pic
+    };
+
+    Ok(single_user_converted)
 }
 
 

--- a/src/statego-backend/src/queries.rs
+++ b/src/statego-backend/src/queries.rs
@@ -63,6 +63,28 @@ pub fn select_password_by_username(conn: &mut mysql::PooledConn, username: Strin
     .map(|pass| pass.unwrap())
 }
 
+pub fn select_single_user(conn: &mut mysql::PooledConn, id: u64) -> mysql::error::Result<SingleUserUnconvertedResponseData> {
+    conn.exec_first(
+        "
+        SELECT email, username, first_name, last_name, pronouns, bio, profile_pic
+        FROM users
+        WHERE id = :id
+        ",
+        params! {
+            "id" => id
+        }
+        //|(email, username, first_name, last_name, pronouns, bio, profile_pic)| SingleUserUnconvertedResponseData {
+        //    email: email,
+        //    username: username,
+        //    first_name: first_name,
+        //    last_name: last_name,
+        //    pronouns: pronouns,
+        //    bio: bio,
+        //    profile_pic: profile_pic
+        //}
+    ).map(|single_user_response|single_user_response.unwrap())
+}
+
 pub fn select_user_by_id(
     conn: &mut mysql::PooledConn,
     username: String,

--- a/src/statego-backend/src/routes.rs
+++ b/src/statego-backend/src/routes.rs
@@ -48,6 +48,17 @@ pub(crate) async fn get_users(data: web::Data<mysql::Pool>) -> actix_web::Result
     Ok(web::Json(users))
 }
 
+// endpoint for getting all users
+#[get("/v1/user/{user_name}")]
+pub(crate) async fn get_single_user(
+    data: web::Data<mysql::Pool>,
+    path: web::Path<String>
+) -> actix_web::Result<impl Responder> {
+    let username: String = path.into_inner();
+    let user = web::block(move || get_single_user_persistence(&data, username)).await??;
+    Ok(web::Json(user))
+}
+
 //endpoint for loging in a user
 #[put("/v1/login")]
 pub(crate) async fn login(
@@ -62,7 +73,7 @@ pub(crate) async fn login(
     Ok(web::Json(user))
 }
 
-// endpoint for creating a new user
+// endpoint for updating a user profile
 #[post("/v1/users/profile")]
 pub(crate) async fn update_user_profile(
     web::Json(user_data): web::Json<UserUpdate>,

--- a/src/statego-backend/src/test.rs
+++ b/src/statego-backend/src/test.rs
@@ -3,7 +3,7 @@ mod tests {
     use crate::routes;
     use crate::models::*;
     use actix_web::{test, web, App};
-    use serde_json::{json, from_str, Value};
+    use serde_json::json;
 
 
     #[actix_rt::test]
@@ -19,16 +19,18 @@ mod tests {
 
 
     #[actix_rt::test]
-    async fn create_user() {
-        //let user_data = UserDetails {
-        //        email: String::from("SweetSouthernHeatBarbecue@gmail.com"),
-        //        username: String::from("ASingleLaysPotatoChip"),
-        //        pass:  String::from("ThisIsGonnaBeHashedAnyway"),
-        //        first_name: String::from("Frito"),
-        //        last_name:  String::from("Lay")
-        //};
+    async fn user_creation_reading_updating_complete() {
+        let user_data = SingleUserConvertedResponseData {
+                email: String::from("SweetSouthernHeatBarbecue@gmail.com"),
+                username: String::from("ASingleLaysPotatoChip"),
+                first_name: Some(String::from("Frito")),
+                last_name:  Some(String::from("Lay")),
+                pronouns: None,
+                bio: Some(String::from("I live in a bowl of other potato chips, but I'm special")),
+                profile_pic: Some(String::from("https://www.eatthis.com/wp-content/uploads/sites/4/2018/09/bowl-potato-chips.jpg?quality=82&strip=1&w=800"))
+        };
 
-        let my_data = json!({ 
+        let create_user_data = json!({ 
                 "email": "SweetSouthernHeatBarbecue@gmail.com",
                 "username": "ASingleLaysPotatoChip",
                 "pass": "ThisIsGonnaBeHashedAnyway",
@@ -39,11 +41,36 @@ mod tests {
         let pool = crate::config::set_up_environment();
         let shared_data = web::Data::new(pool);
         
-        let mut app = test::init_service(App::new().app_data(shared_data.clone()).service(routes::create_user)).await;
-        let req = test::TestRequest::post().uri("/v1/users").set_json(my_data).to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let mut app = test::init_service(
+            App::new()
+            .app_data(shared_data.clone())
+            .service(routes::create_user)
+            .service(routes::update_user_profile)
+            .service(routes::get_single_user)
+            )
+            .await;
+        let mut req = test::TestRequest::post().uri("/v1/users").set_json(create_user_data).to_request();
+        let mut resp = test::call_service(&mut app, req).await;
 
         assert!(resp.status().is_success());
-        let body = test::read_body(resp).await;
+
+        let update_user_data = json!({ 
+            "username": "ASingleLaysPotatoChip",
+            "bio": "I live in a bowl of other potato chips, but I'm special",
+            "profile_pic": "https://www.eatthis.com/wp-content/uploads/sites/4/2018/09/bowl-potato-chips.jpg?quality=82&strip=1&w=800"     
+    });
+        //make request for updating profile and send it to test
+        req = test::TestRequest::post().uri("/v1/users/profile").set_json(update_user_data).to_request();
+        resp = test::call_service(&mut app, req).await;
+        assert!(resp.status().is_success());
+
+        //make request for pulling profile data and extracting it into a struct
+        let finalreq = test::TestRequest::get().uri("/v1/user/AsingleLaysPotatoChip").to_request();
+        resp = test::call_service(&mut app, finalreq).await;
+        let json_response: SingleUserConvertedResponseData = test::read_body_json(resp).await;
+
+        assert_eq!(json_response,user_data);
+
     }
 }
+

--- a/src/statego-backend/src/test.rs
+++ b/src/statego-backend/src/test.rs
@@ -1,76 +1,49 @@
-// This line is a conditional compilation attribute that ensures the contained module (in this case, `tests`) 
-// is only compiled and run when you're executing `cargo test`.
-//#[cfg(test)]
-//mod tests {
-    // Importing necessary modules and types.
-//    use actix_web::{web, App, HttpServer, test, http};
-//    use mysql::{Pool};
-//    use std::{env, io};
-//    use crate::models::*;
-//    use crate::routes::*;
-//    use crate::config::*;
+#[cfg(test)]
+mod tests {
+    use crate::routes;
+    use crate::models::*;
+    use actix_web::{test, web, App};
+    use serde_json::{json, from_str, Value};
 
-    // This is a utility function to set up a connection to the test database.
-    // This function establishes a connection pool to your MySQL database.
-//    fn setup_database() -> Pool {
-//        let pool = Pool::new("mysql://test_db_url").unwrap();
-        // The above line connects to a MySQL database with the specified URL.
-        // Ensure this points to your TEST database, not your production one.
+
+    #[actix_rt::test]
+    async fn test_hello_endpoint() {
+        let mut app = test::init_service(App::new().service(routes::hello)).await;
+        let req = test::TestRequest::get().uri("/").to_request();
+        let resp = test::call_service(&mut app, req).await;
+
+        assert!(resp.status().is_success());
+        let body = test::read_body(resp).await;
+        assert_eq!(body, web::Bytes::from_static(b"Hello, cruel world"));
+    }
+
+
+    #[actix_rt::test]
+    async fn create_user() {
+        //let user_data = UserDetails {
+        //        email: String::from("SweetSouthernHeatBarbecue@gmail.com"),
+        //        username: String::from("ASingleLaysPotatoChip"),
+        //        pass:  String::from("ThisIsGonnaBeHashedAnyway"),
+        //        first_name: String::from("Frito"),
+        //        last_name:  String::from("Lay")
+        //};
+
+        let my_data = json!({ 
+                "email": "SweetSouthernHeatBarbecue@gmail.com",
+                "username": "ASingleLaysPotatoChip",
+                "pass": "ThisIsGonnaBeHashedAnyway",
+                "first_name": "Frito",
+                "last_name": "Lay"     
+        });
+
+        let pool = crate::config::set_up_environment();
+        let shared_data = web::Data::new(pool);
         
-        // Optionally, here you could add code to initialize your database, 
-        // like clearing tables or inserting initial test data.
+        let mut app = test::init_service(App::new().app_data(shared_data.clone()).service(routes::create_user)).await;
+        let req = test::TestRequest::post().uri("/v1/users").set_json(my_data).to_request();
+        let resp = test::call_service(&mut app, req).await;
 
-        // Return the connection pool.
-//        pool
-//    }
-
-    // This line marks the following function as an asynchronous test function.
-//    #[test]
-//    async fn test_update_user_profile_integration() {
-        // Calls the previously defined setup_database function to get a connection pool.
-//        let pool = set_up_environment();
-//        let shared_data = web::Data::new(pool);
-        // This starts an instance of your Actix app inside a test server. 
-        // The test server runs your app in the background, allowing you to send test requests to it.
-//        let srv = HttpServer::new(move || {
-            // serve functions at defined endpoints and bind global data pool
-//            App::new()
-//                .app_data(shared_data.clone())
-//                .service(create_user)
-//                .service(get_users)
-//                .service(hello)
-//                .service(login)
-//                .service(update_user_profile)
-//        })
-//        .bind(("127.0.0.1", 8080))
-//        .run()
-//        .await
-    
-
-        // This constructs and sends a POST request to the `/v1/users/profile` route of your app.
-        // The request sends a JSON body corresponding to a UserUpdate struct.
-//        let request = srv.post("/v1/users/profile")
-//            .set_json(&UserUpdate {
-//                username: "testuser".into(),
-//                bio: Some("Integration Test Bio".into()),
-//                profile_pic: None,
-//            })
-//            // The send() method actually sends the constructed request.
-//            .send()
-//            .await
-//            .expect("Failed to send request.");
-
-        // Asserts (checks) that the response status code is 204 (No Content).
-//        assert_eq!(request.status(), http::StatusCode::NO_CONTENT);
-
-        // The following section validates the changes made to the database.
-        // Gets a database connection from the connection pool.
-//        let mut conn = pool.get_conn().unwrap();
-        // Fetches the user with the given username from the database.
-//        let updated_user: Option<UserUpdate> = conn.query_first(format!("SELECT * FROM users WHERE username='{}'", "testuser")).unwrap();
-        // Asserts that a user was found.
-//        assert!(updated_user.is_some());
-        // Asserts that the bio of the found user matches the one sent in the test request.
-//        assert_eq!(updated_user.unwrap().bio, Some("Integration Test Bio".into()));
-//    }
-//}
+        assert!(resp.status().is_success());
+        let body = test::read_body(resp).await;
+    }
+}


### PR DESCRIPTION
See last commit: "There is a new route and associated persistence/query functions
for getting profile information on a single user. MySQL refuses to
convert it's datetime to String so there is unused code, but it can
be researched and fixed at a later time, so this code just removes any
backend functionality involving "created-time" for a user.
The testing is also not ideal, as it creates a user, updates the user,
and then uses the "get" endpoint to return the profile information.
The bad part about this is that the result is still left in the database.
Not the most complicated thing to solve, especially when we can just delete
it using an endpoint, but that endpoint doesn't exist yet. The endpoint tests
pass when that user isn't in the database, so technically they work".

Most importantly, the test framework for endpoints is there. These tests count as integration tests, not unit tests.
(Closes #93 ) for now
