### PR TITLE
Changes for 106-backend-create-session-delete-endpoint

### DIFF
--- a/src/statego-backend/src/config.rs
+++ b/src/statego-backend/src/config.rs
@@ -1,7 +1,6 @@
 use mysql::{Pool, SslOpts};
 use std::env;
 
-
 // set up database connection from .env file and return a connection pool
 pub fn set_up_environment() -> Pool {
     // import environment variables from .env file
@@ -40,4 +39,24 @@ pub fn get_conn_builder(
             SslOpts::default(),
             true,
         ))
+}
+
+//logger is conflicting with test environment, according to online sources this is due to initializing it for every test?
+pub fn set_up_test_environment() -> Pool {
+    // import environment variables from .env file
+    dotenv::dotenv().ok();
+    //env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+    //log::info!("setting up app from environment");
+
+    let db_user = env::var("MYSQL_USER").expect("MYSQL_USER is not set in .env file");
+    let db_password = env::var("MYSQL_PASSWORD").expect("MYSQL_PASSWORD is not set in .env file");
+    let db_host = env::var("MYSQL_HOST").expect("MYSQL_HOST is not set in .env file");
+    let db_port = env::var("MYSQL_PORT").expect("MYSQL_PORT is not set in .env file");
+    let db_name = env::var("MYSQL_DBNAME").expect("MYSQL_DBNAME is not set in .env file");
+    let db_port = db_port.parse().unwrap();
+
+    // create a connection builder from environment
+    let builder = get_conn_builder(db_user, db_password, db_host, db_port, db_name);
+    //log::info!("initializing database connection");
+    mysql::Pool::new(builder).unwrap()
 }

--- a/src/statego-backend/src/main.rs
+++ b/src/statego-backend/src/main.rs
@@ -1,21 +1,20 @@
 /////////////////////////////////////////////
 /// main.rs
-/// 
+///
 /// handles loading environment variables
 /// handles setting up database connection
 /// handles staring the server
 /////////////////////////////////////////////
-
 use actix_web::{web, App, HttpServer};
 use std::io;
 
 // modules from other files in project
+mod config;
 mod models;
 mod persistence;
 mod queries;
 mod routes;
 mod test;
-mod config;
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {
@@ -40,10 +39,11 @@ async fn main() -> io::Result<()> {
             .service(routes::get_list_of_games)
             .service(routes::get_list_of_campaigns)
             .service(routes::get_single_user)
+            .service(routes::delete_session)
+            .service(routes::get_single_session)
     })
     .bind(("127.0.0.1", 8080))?
     .workers(2)
     .run()
     .await
 }
-

--- a/src/statego-backend/src/models.rs
+++ b/src/statego-backend/src/models.rs
@@ -1,12 +1,11 @@
 /////////////////////////////////////////////
+use chrono::NaiveDateTime;
 /// models.rs
-/// 
+///
 /// data models that map to the mysql queries
 /////////////////////////////////////////////
-
 use mysql::prelude::FromRow;
 use serde::{Deserialize, Serialize};
-use chrono::NaiveDateTime;
 
 #[derive(Debug, Deserialize)]
 pub struct UserDetails {
@@ -14,7 +13,7 @@ pub struct UserDetails {
     pub username: String,
     pub pass: String,
     pub first_name: String,
-    pub last_name: String
+    pub last_name: String,
 }
 
 #[derive(Debug, Serialize, FromRow)]
@@ -26,7 +25,6 @@ pub struct UserData {
     pub last_name: String,
 }
 
-
 #[derive(Debug, Serialize, FromRow)]
 pub struct SingleUserUnconvertedResponseData {
     //pub create_time: String,
@@ -36,7 +34,7 @@ pub struct SingleUserUnconvertedResponseData {
     pub last_name: Option<String>,
     pub pronouns: Option<String>,
     pub bio: Option<String>,
-    pub profile_pic: Option<String>
+    pub profile_pic: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Deserialize)]
@@ -48,7 +46,7 @@ pub struct SingleUserConvertedResponseData {
     pub last_name: Option<String>,
     pub pronouns: Option<String>,
     pub bio: Option<String>,
-    pub profile_pic: Option<String>
+    pub profile_pic: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -76,7 +74,7 @@ pub struct UserUpdateData {
     pub profile_pic: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Session {
     pub username: String,
     pub game_title: String,
@@ -89,12 +87,15 @@ pub struct Session {
     pub notes: Option<String>,
     pub winner: bool,
     pub winner_name: Option<String>,
-    pub picture: Option<String>
-
+    pub picture: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct SessionDataConverted {
+    pub session_id : u64,
+    pub user_name : String,
+    pub game_title : String,
+    pub campaign_title : Option<String>,
     #[serde(with = "my_date_format")]
     pub session_start: NaiveDateTime,
     #[serde(with = "my_date_format")]
@@ -104,12 +105,15 @@ pub struct SessionDataConverted {
     pub winner: bool,
     pub winner_name: Option<String>,
     pub picture: Option<String>,
-    pub number_of_players: i8
+    pub number_of_players: i8,
 }
-
 
 #[derive(Debug, Serialize, FromRow)]
 pub struct SessionDataUnConverted {
+    pub session_id : u64,
+    pub user_id : u64,
+    pub game_id : u64,
+    pub campaign_id : Option<u64>,
     pub session_start: String,
     pub session_end: String,
     pub players: String,
@@ -117,26 +121,26 @@ pub struct SessionDataUnConverted {
     pub winner: bool,
     pub winner_name: Option<String>,
     pub picture: Option<String>,
-    pub number_of_players: i8
+    pub number_of_players: i8,
 }
 
 #[derive(Debug, Serialize)]
 pub struct SessionResponseVec {
-    pub session_list: Vec<SessionDataConverted>
+    pub session_list: Vec<SessionDataConverted>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct SessionsFind {
     pub username: String,
     pub game_title: String,
-    pub campaign_title: Option<String>
+    pub campaign_title: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct NewGame {
     pub username: String,
     pub game_title: String,
-    pub description: Option<String>
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -145,7 +149,7 @@ pub struct NewCampaign {
     pub game_title: String,
     pub campaign_title: String,
     pub description: Option<String>,
-    pub notes: Option<String>
+    pub notes: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -156,7 +160,7 @@ pub struct GameFind {
 #[derive(Debug, Deserialize)]
 pub struct CampaignFind {
     pub username: String,
-    pub game_title: String
+    pub game_title: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -170,20 +174,15 @@ pub struct GameInfo {
 pub struct CampaignInfo {
     pub campaign_title: String,
     pub description: Option<String>,
-    pub notes: Option<String>
+    pub notes: Option<String>,
 }
 
-
-mod my_date_format{
+mod my_date_format {
     use chrono::NaiveDateTime;
-    use serde::{self, Deserialize, Serializer, Deserializer};
-
+    use serde::{self, Deserialize, Deserializer, Serializer};
 
     const FORMAT: &'static str = "%Y-%m-%d %H:%M:%S";
-    pub fn serialize<S>(
-        date: &NaiveDateTime,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(date: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -191,9 +190,7 @@ mod my_date_format{
         serializer.serialize_str(&s)
     }
 
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<NaiveDateTime, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<NaiveDateTime, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -202,6 +199,3 @@ mod my_date_format{
         Ok(dt)
     }
 }
-
-
-

--- a/src/statego-backend/src/persistence.rs
+++ b/src/statego-backend/src/persistence.rs
@@ -1,14 +1,13 @@
 /////////////////////////////////////////////
 /// persistence.rs
-/// 
+///
 /// handles error checking on requests
 /// handles authentication of users
 /////////////////////////////////////////////
-
 use actix_web::http::StatusCode;
 use bcrypt::{hash, verify, DEFAULT_COST};
+use chrono::{prelude::*, NaiveDateTime};
 use derive_more::{Display, Error, From};
-use chrono::{NaiveDateTime, prelude::*};
 
 use crate::models::*;
 use crate::queries::*;
@@ -21,7 +20,7 @@ pub enum PersistenceError {
     BcryptError(bcrypt::BcryptError),
     MysqlError(mysql::Error),
     UnknownUser,
-    Unknown
+    Unknown,
 }
 
 //matches a PersistenceError to a StatusCode
@@ -109,7 +108,10 @@ pub fn get_users_verify(pool: &mysql::Pool) -> Result<UserResponseData, Persiste
     })
 }
 
-pub fn get_single_user_persistence(pool: &mysql::Pool, username: String) -> Result<SingleUserConvertedResponseData, PersistenceError> {
+pub fn get_single_user_persistence(
+    pool: &mysql::Pool,
+    username: String,
+) -> Result<SingleUserConvertedResponseData, PersistenceError> {
     let mut conn = pool.get_conn()?;
 
     if username.replace(' ', "").trim().is_empty() {
@@ -137,26 +139,71 @@ pub fn get_single_user_persistence(pool: &mysql::Pool, username: String) -> Resu
         last_name: single_user.last_name,
         pronouns: single_user.pronouns,
         bio: single_user.bio,
-        profile_pic: single_user.profile_pic
+        profile_pic: single_user.profile_pic,
     };
 
     Ok(single_user_converted)
 }
 
+pub fn get_single_session_persistence(
+    pool: &mysql::Pool,
+    session_id: u64,
+) -> Result<SessionDataConverted, PersistenceError> {
+    let mut conn = pool.get_conn()?;
+    let single_session_unconverted_vec = get_single_session_query(&mut conn, session_id).unwrap();
+    let single_session_unconverted = single_session_unconverted_vec.first().unwrap();
+    //get strings for user_id, game_id, and campaign_id (if some)
+    let user_name = select_userstring_by_userid(&mut conn, single_session_unconverted.user_id).unwrap();
+    let game_title = select_gamestring_by_gameid(&mut conn, single_session_unconverted.game_id).unwrap();
+    let mut campaign_title: Option<String> = None;
+    if single_session_unconverted.campaign_id.is_some(){
+        campaign_title = Some(select_campaignstring_by_campaignid(&mut conn, single_session_unconverted.campaign_id.unwrap()).unwrap());
+    }
+    let converted_session_start = string_to_NaiveDateTime(single_session_unconverted.session_start.clone());
+    let converted_session_end = string_to_NaiveDateTime(single_session_unconverted.session_end.clone());
+    let players_str_vec: Vec<&str> = single_session_unconverted.players.split(',').collect();
+        let players_string_vec: Vec<String> =
+            players_str_vec.into_iter().map(|s| s.to_string()).collect();
+
+
+    let single_session_converted = SessionDataConverted {
+        //create_time: create_time_datetime,
+        session_id: single_session_unconverted.session_id,
+        user_name: user_name,
+        game_title: game_title,
+        campaign_title: campaign_title,
+        session_start: converted_session_start,
+        session_end: converted_session_end,
+        players: players_string_vec,
+        notes: single_session_unconverted.notes.clone(),
+        winner: single_session_unconverted.winner,
+        winner_name: single_session_unconverted.winner_name.clone(),
+        picture: single_session_unconverted.picture.clone(),
+        number_of_players: single_session_unconverted.number_of_players
+        
+    };
+
+    Ok(single_session_converted)
+}
 
 //function that checks if user exists and calls the query to update
 pub fn update_user(
     pool: &mysql::Pool,
     username: String,
     bio: String,
-    profile_pic: String
+    profile_pic: String,
 ) -> Result<UserUpdateData, PersistenceError> {
     let mut conn = pool.get_conn()?;
 
     if username.replace(' ', "").trim().is_empty() {
         Err(PersistenceError::EmptyUsername)
     } else {
-        Ok(update_bio_and_profilepic(&mut conn, username, bio, profile_pic)?)
+        Ok(update_bio_and_profilepic(
+            &mut conn,
+            username,
+            bio,
+            profile_pic,
+        )?)
     }
 }
 
@@ -171,67 +218,66 @@ pub fn create_session_persistence(
     notes: Option<String>,
     winner: bool,
     winner_name: Option<String>,
-    picture: Option<String>
+    picture: Option<String>,
 ) -> Result<(), PersistenceError> {
     let mut conn = pool.get_conn()?;
     //get number of players
     let number_of_players = players.len() as i8;
     //turn players vector into a string
     let player_string = players.join(","); // Seperated by commas
-    //get user_id
+                                           //get user_id
     let user_id = select_userid_by_userstring(&mut conn, username).unwrap();
     //get game_id
     let game_id = select_gameid_by_gamestring(&mut conn, game_title).unwrap();
     //if campaign isn't empty, get campaign_id
     let mut campaign_id: Option<u64> = None;
-    if !campaign_title.is_none(){
+    if !campaign_title.is_none() {
         campaign_id = Some(select_campaignid_by_campaignstring(&mut conn, campaign_title).unwrap());
     }
-    //format for naivedatetime strings will "YYYY, MM, DD, HH, MM, SS"
-    //I realize this is the dumbest way to do this ever but due to
-    //funkiness in the mysql crate not implementing From conversion for NaiveDateTime,
-    //this is unavoidable, and must be considered when implementing pulling from database
-    //If it makes you feel better, NaiveDateTimes can be subtracted in a complicated way
-    //so elapsed time of sessions will NOT have to be implemented from scratch
-    let year_str = session_start.date().year().to_string();
-    let month_str = session_start.date().month().to_string();
-    let day_str = session_start.date().day().to_string();
-    let hour_str = session_start.time().hour().to_string();
-    let minute_str = session_start.time().minute().to_string();
-    let second_str = session_start.time().second().to_string();
-    let mut session_vec_start: Vec<String> = Vec::new();
-    session_vec_start.push(year_str);
-    session_vec_start.push(month_str);
-    session_vec_start.push(day_str);
-    session_vec_start.push(hour_str);
-    session_vec_start.push(minute_str);
-    session_vec_start.push(second_str);
-    let session_start_string = session_vec_start.join(",");
-    let year_str = session_end.date().year().to_string();
-    let month_str = session_end.date().month().to_string();
-    let day_str = session_end.date().day().to_string();
-    let hour_str = session_end.time().hour().to_string();
-    let minute_str = session_end.time().minute().to_string();
-    let second_str = session_end.time().second().to_string();
-    let mut session_vec_end: Vec<String> = Vec::new();
-    session_vec_end.push(year_str);
-    session_vec_end.push(month_str);
-    session_vec_end.push(day_str);
-    session_vec_end.push(hour_str);
-    session_vec_end.push(minute_str);
-    session_vec_end.push(second_str);
-    let session_end_string = session_vec_end.join(",");
+    let session_start_string = naive_date_time_to_string(session_start);
+    let session_end_string = naive_date_time_to_string(session_end);
 
-    let last_insert_id = create_session_in_database(&mut conn, user_id, game_id, campaign_id, session_start_string, session_end_string, player_string,
-    number_of_players, notes, winner, winner_name, picture);
-   
+    let last_insert_id = create_session_in_database(
+        &mut conn,
+        user_id,
+        game_id,
+        campaign_id,
+        session_start_string,
+        session_end_string,
+        player_string,
+        number_of_players,
+        notes,
+        winner,
+        winner_name,
+        picture,
+    );
+
     if last_insert_id.unwrap() > 0 {
         Ok(())
     } else {
         Err(PersistenceError::Unknown)
     }
+}
 
+pub fn delete_session_persistence(
+    pool: &mysql::Pool,
+    session_id: u64
+) -> Result<(), PersistenceError> {
+    let mut conn = pool.get_conn()?;
+    //pass in deletion
+    let is_deleted: bool = true;
     
+    let affected_rows = delete_session_in_database(
+        &mut conn,
+        session_id,
+        is_deleted
+    );
+
+    if affected_rows.unwrap() > 0 {
+        Ok(())
+    } else {
+        Err(PersistenceError::Unknown)
+    }
 }
 
 //function that checks if user exists and calls the query to update
@@ -241,6 +287,11 @@ pub fn get_list_of_sessions_persistence(
     game_title: String,
     campaign_title: Option<String>,
 ) -> Result<Vec<SessionDataConverted>, PersistenceError> {
+
+    let username2 = username.clone();
+    let game_title2 = game_title.clone();
+    let campaign_title2 = campaign_title.clone();
+
     let mut conn = pool.get_conn()?;
     //get user_id
     let user_id = select_userid_by_userstring(&mut conn, username).unwrap();
@@ -248,49 +299,34 @@ pub fn get_list_of_sessions_persistence(
     let game_id = select_gameid_by_gamestring(&mut conn, game_title).unwrap();
     //if campaign isn't empty, get campaign_id
     let mut campaign_id: Option<u64> = None;
-    if !campaign_title.is_none(){
+    if !campaign_title.is_none() {
         campaign_id = Some(select_campaignid_by_campaignstring(&mut conn, campaign_title).unwrap());
     }
+
     
-    let unconverted_session_vec = (get_list_of_sessions_queries(&mut conn, user_id, game_id, campaign_id)).unwrap();
+    let unconverted_session_vec =
+        (get_list_of_sessions_queries(&mut conn, user_id, game_id, campaign_id)).unwrap();
 
     let mut converted_session_vec: Vec<SessionDataConverted> = Vec::new();
     for SessionDataUnConverted in unconverted_session_vec {
         //create SessionDataConverted Object last
-        
+
         //split session_start string into a vector of strings
-        let session_start_vec: Vec<&str> = SessionDataUnConverted.session_start.split(',').collect();
-
-        //create NaiveDateTime object out of string
-        let year = session_start_vec[0].parse::<i32>();
-        let month = session_start_vec[1].parse::<u32>();
-        let day = session_start_vec[2].parse::<u32>();
-        let hour = session_start_vec[3].parse::<u32>();
-        let minute = session_start_vec[4].parse::<u32>();
-        let second = session_start_vec[5].parse::<u32>();
-        let date = NaiveDate::from_ymd_opt(year.unwrap(), month.unwrap(), day.unwrap()).unwrap();
-        let time = NaiveTime::from_hms_opt(hour.unwrap(), minute.unwrap(), second.unwrap()).unwrap();
-        let session_start_datetime = NaiveDateTime::new(date, time);
-
-        let session_end_vec: Vec<&str> = SessionDataUnConverted.session_end.split(',').collect();
-        //create NaiveDateTime object out of string
-        let year = session_end_vec[0].parse::<i32>();
-        let month = session_end_vec[1].parse::<u32>();
-        let day = session_end_vec[2].parse::<u32>();
-        let hour = session_end_vec[3].parse::<u32>();
-        let minute = session_end_vec[4].parse::<u32>();
-        let second = session_end_vec[5].parse::<u32>();
-        let date = NaiveDate::from_ymd_opt(year.unwrap(), month.unwrap(), day.unwrap()).unwrap();
-        let time = NaiveTime::from_hms_opt(hour.unwrap(), minute.unwrap(), second.unwrap()).unwrap();
-        let session_end_datetime = NaiveDateTime::new(date, time);
+        let session_start_datetime = string_to_NaiveDateTime(SessionDataUnConverted.session_start);
+        let session_end_datetime = string_to_NaiveDateTime(SessionDataUnConverted.session_end);
 
         //turn players string into a vector of &str, and then into a vector of Strings for return
         let players_str_vec: Vec<&str> = SessionDataUnConverted.players.split(',').collect();
-        let players_string_vec: Vec<String> = players_str_vec.into_iter().map(|s| s.to_string()).collect();
+        let players_string_vec: Vec<String> =
+            players_str_vec.into_iter().map(|s| s.to_string()).collect();
 
-        let converted_session_data = SessionDataConverted{
+        let converted_session_data = SessionDataConverted {
+            session_id: SessionDataUnConverted.session_id,
+            user_name: username2.clone(),
+            game_title: game_title2.clone(),
+            campaign_title: campaign_title2.clone(),
             session_start: session_start_datetime,
-            session_end:    session_end_datetime,
+            session_end: session_end_datetime,
             players: players_string_vec,
             notes: SessionDataUnConverted.notes,
             winner: SessionDataUnConverted.winner,
@@ -298,13 +334,12 @@ pub fn get_list_of_sessions_persistence(
             picture: SessionDataUnConverted.picture,
             number_of_players: SessionDataUnConverted.number_of_players
         };
-        
+
         converted_session_vec.push(converted_session_data);
     }
 
     //see using the struct declared for models when dealing with errors
     Ok(converted_session_vec)
-    
 }
 
 pub fn create_new_game_persistence(
@@ -314,17 +349,16 @@ pub fn create_new_game_persistence(
     description: Option<String>,
 ) -> Result<(), PersistenceError> {
     let mut conn = pool.get_conn()?;
-    
+
     //get user_id
     let user_id = select_userid_by_userstring(&mut conn, username).unwrap();
-    
+
     let last_insert_id = create_game_in_database(&mut conn, user_id, game_title, description);
     if last_insert_id.unwrap() > 0 {
         Ok(())
     } else {
         Err(PersistenceError::Unknown)
     }
-    
 }
 
 pub fn create_new_campaign_persistence(
@@ -333,24 +367,29 @@ pub fn create_new_campaign_persistence(
     game_title: String,
     campaign_title: String,
     description: Option<String>,
-    notes: Option<String>
+    notes: Option<String>,
 ) -> Result<(), PersistenceError> {
     let mut conn = pool.get_conn()?;
-    
+
     //get user_id
     let user_id = select_userid_by_userstring(&mut conn, username).unwrap();
     //get game_id
     let game_id = select_gameid_by_gamestring(&mut conn, game_title).unwrap();
-    
-    let last_insert_id = create_campaign_in_database(&mut conn, user_id, game_id, campaign_title, description, notes);
+
+    let last_insert_id = create_campaign_in_database(
+        &mut conn,
+        user_id,
+        game_id,
+        campaign_title,
+        description,
+        notes,
+    );
     if last_insert_id.unwrap() > 0 {
         Ok(())
     } else {
         Err(PersistenceError::Unknown)
     }
-    
 }
-
 
 pub fn get_list_of_games_persistence(
     pool: &mysql::Pool,
@@ -362,14 +401,12 @@ pub fn get_list_of_games_persistence(
     let games_vec = (get_list_of_games_queries(&mut conn, user_id)).unwrap();
     //see using the struct declared for models when dealing with errors
     Ok(games_vec)
-    
 }
-
 
 pub fn get_list_of_campaigns_persistence(
     pool: &mysql::Pool,
     username: String,
-    game_title: String
+    game_title: String,
 ) -> Result<Vec<CampaignInfo>, PersistenceError> {
     let mut conn = pool.get_conn()?;
     //get user_id
@@ -378,5 +415,42 @@ pub fn get_list_of_campaigns_persistence(
     let campaigns_vec = (get_list_of_campaigns_queries(&mut conn, user_id, game_id)).unwrap();
     //see using the struct declared for models when dealing with errors
     Ok(campaigns_vec)
-    
+}
+
+pub fn naive_date_time_to_string(
+    date: NaiveDateTime,
+) -> String {
+    let year_str = date.date().year().to_string();
+    let month_str = date.date().month().to_string();
+    let day_str = date.date().day().to_string();
+    let hour_str = date.time().hour().to_string();
+    let minute_str = date.time().minute().to_string();
+    let second_str = date.time().second().to_string();
+    let mut date_vec: Vec<String> = Vec::new();
+    date_vec.push(year_str);
+    date_vec.push(month_str);
+    date_vec.push(day_str);
+    date_vec.push(hour_str);
+    date_vec.push(minute_str);
+    date_vec.push(second_str);
+    let date_string = date_vec.join(",");
+    return date_string;
+}
+
+pub fn string_to_NaiveDateTime(
+     date: String
+) -> NaiveDateTime {
+    let string_vec: Vec<&str> = date.split(',').collect();
+        //create NaiveDateTime object out of string
+        let year = string_vec[0].parse::<i32>();
+        let month = string_vec[1].parse::<u32>();
+        let day = string_vec[2].parse::<u32>();
+        let hour = string_vec[3].parse::<u32>();
+        let minute = string_vec[4].parse::<u32>();
+        let second = string_vec[5].parse::<u32>();
+        let date = NaiveDate::from_ymd_opt(year.unwrap(), month.unwrap(), day.unwrap()).unwrap();
+        let time =
+            NaiveTime::from_hms_opt(hour.unwrap(), minute.unwrap(), second.unwrap()).unwrap();
+        let session_start_datetime = NaiveDateTime::new(date, time);
+        return session_start_datetime;
 }

--- a/src/statego-backend/src/test.rs
+++ b/src/statego-backend/src/test.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use crate::routes;
     use crate::models::*;
+    use crate::routes;
     use actix_web::{test, web, App};
     use serde_json::json;
-
+    use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
 
     #[actix_rt::test]
-    async fn test_hello_endpoint() {
+    async fn a_test_hello_endpoint() {
         let mut app = test::init_service(App::new().service(routes::hello)).await;
         let req = test::TestRequest::get().uri("/").to_request();
         let resp = test::call_service(&mut app, req).await;
@@ -17,9 +17,8 @@ mod tests {
         assert_eq!(body, web::Bytes::from_static(b"Hello, cruel world"));
     }
 
-
     #[actix_rt::test]
-    async fn user_creation_reading_updating_complete() {
+    async fn b_user_creation_reading_updating_complete() {
         let user_data = SingleUserConvertedResponseData {
                 email: String::from("SweetSouthernHeatBarbecue@gmail.com"),
                 username: String::from("ASingleLaysPotatoChip"),
@@ -30,47 +29,163 @@ mod tests {
                 profile_pic: Some(String::from("https://www.eatthis.com/wp-content/uploads/sites/4/2018/09/bowl-potato-chips.jpg?quality=82&strip=1&w=800"))
         };
 
-        let create_user_data = json!({ 
+        let create_user_data = json!({
                 "email": "SweetSouthernHeatBarbecue@gmail.com",
                 "username": "ASingleLaysPotatoChip",
                 "pass": "ThisIsGonnaBeHashedAnyway",
                 "first_name": "Frito",
-                "last_name": "Lay"     
+                "last_name": "Lay"
         });
 
-        let pool = crate::config::set_up_environment();
+        let pool = crate::config::set_up_test_environment();
         let shared_data = web::Data::new(pool);
-        
+
         let mut app = test::init_service(
             App::new()
-            .app_data(shared_data.clone())
-            .service(routes::create_user)
-            .service(routes::update_user_profile)
-            .service(routes::get_single_user)
-            )
-            .await;
-        let mut req = test::TestRequest::post().uri("/v1/users").set_json(create_user_data).to_request();
+                .app_data(shared_data.clone())
+                .service(routes::create_user)
+                .service(routes::update_user_profile)
+                .service(routes::get_single_user),
+        )
+        .await;
+        let mut req = test::TestRequest::post()
+            .uri("/v1/users")
+            .set_json(create_user_data)
+            .to_request();
         let mut resp = test::call_service(&mut app, req).await;
 
         assert!(resp.status().is_success());
 
-        let update_user_data = json!({ 
-            "username": "ASingleLaysPotatoChip",
-            "bio": "I live in a bowl of other potato chips, but I'm special",
-            "profile_pic": "https://www.eatthis.com/wp-content/uploads/sites/4/2018/09/bowl-potato-chips.jpg?quality=82&strip=1&w=800"     
-    });
+        let update_user_data = json!({
+                "username": "ASingleLaysPotatoChip",
+                "bio": "I live in a bowl of other potato chips, but I'm special",
+                "profile_pic": "https://www.eatthis.com/wp-content/uploads/sites/4/2018/09/bowl-potato-chips.jpg?quality=82&strip=1&w=800"
+        });
         //make request for updating profile and send it to test
-        req = test::TestRequest::post().uri("/v1/users/profile").set_json(update_user_data).to_request();
+        req = test::TestRequest::post()
+            .uri("/v1/users/profile")
+            .set_json(update_user_data)
+            .to_request();
         resp = test::call_service(&mut app, req).await;
         assert!(resp.status().is_success());
 
         //make request for pulling profile data and extracting it into a struct
-        let finalreq = test::TestRequest::get().uri("/v1/user/AsingleLaysPotatoChip").to_request();
+        let finalreq = test::TestRequest::get()
+            .uri("/v1/user/AsingleLaysPotatoChip")
+            .to_request();
         resp = test::call_service(&mut app, finalreq).await;
         let json_response: SingleUserConvertedResponseData = test::read_body_json(resp).await;
 
-        assert_eq!(json_response,user_data);
+        assert_eq!(json_response, user_data);
+    
+    
+        let new_game = NewGame {
+                username: String::from("ASingleLaysPotatoChip"),
+                game_title: String::from("Hello Kitty Island Adventure"),
+                description: Some(String::from("Animal Crossing but good"))
+        };
 
+
+        let new_game_data = json!({
+                "username": "ASingleLaysPotatoChip",
+                "game_title": "Hello Kitty Island Adventure",
+                "description": "Animal Crossing but good",
+        });
+
+        let pool = crate::config::set_up_test_environment();
+        let shared_data = web::Data::new(pool);
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(shared_data.clone())
+                .service(routes::create_game)
+                .service(routes::create_campaign)
+                .service(routes::create_session)
+        )
+        .await;
+
+        //make request for posting game and sending it to test
+        let mut req = test::TestRequest::post()
+            .uri("/v1/users/game")
+            .set_json(new_game_data)
+            .to_request();
+        let mut resp = test::call_service(&mut app, req).await;
+
+        assert!(resp.status().is_success());
+
+        let new_campaign = NewCampaign {
+            username: String::from("ASingleLaysPotatoChip"),
+            game_title: String::from("Hello Kitty Island Adventure"),
+            campaign_title: String::from("Descent into Avernus"),
+            description: Some(String::from("A quest to rescue Elturel from the depths")),
+            notes: Some(String::from("Questioning the reason why the developers implemented death animations in Hello Kitty"))
+        };
+
+        let new_campaign_data = json!({
+                "username": "ASingleLaysPotatoChip",
+                "game_title": "Hello Kitty Island Adventure",
+                "campaign_title": "Descent into Avernus",
+                "description": "A quest to rescue Elturel from the depths",
+                "notes": "Questioning the reason why the developers implemented death animations in Hello Kitty"
+        });
+
+        //make request for posting campaign and send it to test
+        req = test::TestRequest::post()
+            .uri("/v1/users/campaign")
+            .set_json(new_campaign_data)
+            .to_request();
+        resp = test::call_service(&mut app, req).await;
+        assert!(resp.status().is_success());
+
+        let start_date = NaiveDate::from_ymd_opt(2040, 1, 1);
+        let start_time = NaiveTime::from_hms_opt(12, 30, 45);
+        let start_datetime = NaiveDateTime::new(start_date.unwrap(),start_time.unwrap());
+
+        let end_date = NaiveDate::from_ymd_opt(2040, 1, 1);
+        let end_time = NaiveTime::from_hms_opt(16, 30, 45);
+        let end_datetime = NaiveDateTime::new(end_date.unwrap(),end_time.unwrap());
+        
+        let player_strings_vec = vec![String::from("Papapia"), String::from("Mamamia"), String::from("ASingleLaysPotatoChip")];
+
+        let new_session = Session {
+            username: String::from("ASingleLaysPotatoChip"),
+            game_title: String::from("Hello Kitty Island Adventure"),
+            campaign_title: Some(String::from("Descent into Avernus")),
+            session_start: start_datetime,
+            session_end: end_datetime,
+            players: player_strings_vec,
+            notes: Some(String::from("We enjoyed saving the merchant from wolves")),
+            winner: false,
+            winner_name: None,
+            picture: None
+        };
+
+        let new_session_data = json!({
+                "username": "ASingleLaysPotatoChip",
+                "game_title": "Hello Kitty Island Adventure",
+                "campaign_title": "Descent into Avernus",
+                "session_start": "2040-01-01 12:30:45",
+                "session_end": "2040-01-01 16:30:45",
+                "players": ["Papapia", "Mamamia", "ASingleLaysPotatoChip"],
+                "notes": "We enjoyed saving the merchant from wolves",
+                "winner": false
+        });
+
+        //make request for posting session and send it to test
+        req = test::TestRequest::post()
+            .uri("/v1/users/session")
+            .set_json(new_session_data)
+            .to_request();
+        resp = test::call_service(&mut app, req).await;
+        assert!(resp.status().is_success());
+
+        //make request for pulling profile data and extracting it into a struct
+        //let finalreq = test::TestRequest::get()
+        //    .uri("/v1/user/AsingleLaysPotatoChip")
+        //    .to_request();
+        //resp = test::call_service(&mut app, finalreq).await;
+        //let json_response: SingleUserConvertedResponseData = test::read_body_json(resp).await;
+
+        //assert_eq!(json_response, user_data);
     }
 }
-


### PR DESCRIPTION
Added new sections to the integration test, made two new endpoints, one for deleting a session and one for getting a single session. The get_session_list route now returns a session_id so info for a single session can be returned. An important note about the delete endpoint, it changes the recently added "is_deleted" column in the database to true. One of the parts of implementing these delete endpoints is making sure the get endpoints don't pull deleted data, which is not currently implemented. There is also a more fleshed out integration test for creating games/campaigns/endpoints for a single user.